### PR TITLE
Bumped manifest version

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,5 +1,5 @@
 {
-  "manifest_version": 2,
+  "manifest_version": 3,
   "name": "BeeBrowse",
   "version": "0.0.5",
   "description": "The unofficial Beeminder browser extension.",


### PR DESCRIPTION
Using Arc 1.79.1 I noticed a warning due to deprecated `manifest_version` value.

It coincided with plug-in not working.

An LLM thought this change would be okay, it seems to be the case for me :)